### PR TITLE
Fix README for Multi-GPU machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The models in the paper can be trained using the configs provided in the `config
 
 ```shell
 # mnist experiment on 1 GPU
-accelerate launch train.py config_file=configs/mnist_discrete.yaml
+accelerate launch --num_processes=1 train.py config_file=configs/mnist_discrete.yaml
 # cifar10 experiment on 1 GPU (A100)
-accelerate launch train.py config_file=configs/cifar10_discretized_256bins.yaml
+accelerate launch --num_processes=1 train.py config_file=configs/cifar10_discretized_256bins.yaml
 # text8 experiment on 8 GPUs (A100)
 accelerate launch --multi_gpu --num_processes=8 --num_machines=1 --dynamo_backend=no --mixed_precision=fp16 train.py config_file=configs/text8_discrete.yaml 
 ```


### PR DESCRIPTION
Hello, thank you for open-sourcing the code to your paper! I was trying to replicate some of the results in your paper and I noticed that running the single GPU experiments (Discrete MNIST and CIFAR10) on a multi-GPU machine resulted in the errors:

```
**RuntimeError**:  CUDA error: invalid device ordinal
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1.
```

whenever using a GPU that is not 0. Simply adding the flag

`--num_processes=1
`
fixes this issue and allows to use the _**accelerate**_ library for multiple concurrent single-GPU experiments.

This PR is quite simple and changes the README to reflect this.