### PR TITLE
fix using track_files when neptune isnt available

### DIFF
--- a/train.py
+++ b/train.py
@@ -152,7 +152,8 @@ def train(
 
             if is_main and (step % cfg.checkpoint_interval == 0):
                 checkpoint_training_state(checkpoint_root_dir / "last", accelerator, ema_model, step, run_id)
-                run["checkpoints/last"].track_files(str(checkpoint_root_dir / "last"))
+                if not isinstance(run, defaultdict):
+                    run["checkpoints/last"].track_files(str(checkpoint_root_dir / "last"))
 
             log(run["metrics"]["train"]["loss"], step_loss / cfg.accumulate, step, is_main and step % cfg.log_interval == 0)
             log(run["metrics"]["epoch"], step // len(dataloaders["train"]), step, is_main)


### PR DESCRIPTION
without neptune, run is a defaultdict and has no .track_files(). just skip it since run['checkpoints/last'] isnt used otherwise.